### PR TITLE
Laravel 8.x is supported now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,14 @@ composer.lock
 # IDEs
 /nbproject
 /.idea
+/.vscode
 
 # Vendors
 /vendor
 
-# etc.
+# Temp dirs & trash
 /temp
 /tmp
-/build
+/coverage
+.DS_Store
+*.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v2.3.0
+
+### Changed
+
+- Laravel `8.x` is supported
+- Minimal Laravel version now is `6.0` (Laravel `5.5` LTS got last security update August 30th, 2020)
+- Dependency `tarampampam/wrappers-php` version `~2.0` is supported
+
 ## v2.2.0
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM php:7.2.5-alpine
+FROM php:7.3.5-alpine
 
 ENV \
     COMPOSER_ALLOW_SUPERUSER="1" \
     COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:1.10.7 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:1.10.10 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \
     && apk add --no-cache --virtual .build-deps autoconf pkgconf make g++ gcc 1>/dev/null \
     # install xdebug (for testing with code coverage), but do not enable it
-    && pecl install xdebug-2.9.1 1>/dev/null \
+    && pecl install xdebug-2.9.6 1>/dev/null \
     && apk del .build-deps \
     && mkdir /src ${COMPOSER_HOME} \
     && composer global require 'hirak/prestissimo' --no-interaction --no-suggest --prefer-dist \

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,8 @@
 # Makefile readme (ru): <http://linux.yaroslavl.ru/docs/prog/gnu_make_3-79_russian_manual.html>
 # Makefile readme (en): <https://www.gnu.org/software/make/manual/html_node/index.html#SEC_Contents>
 
-dc_bin := $(shell command -v docker-compose 2> /dev/null)
-
 SHELL = /bin/sh
-RUN_APP_ARGS = --rm --user "$(shell id -u):$(shell id -g)" app
+RUN_APP_ARGS = --rm --user "$(shell id -u):$(shell id -g)"
 
 .PHONY : help build latest install lowest test test-cover shell clean
 .DEFAULT_GOAL : help
@@ -16,26 +14,25 @@ help: ## Show this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[32m%-14s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 build: ## Build docker images, required for current package environment
-	$(dc_bin) build
+	docker-compose build
 
 latest: clean ## Install latest php dependencies
-	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --ansi --no-suggest --prefer-dist --prefer-stable
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --no-suggest --prefer-dist --prefer-stable
 
 install: clean ## Install regular php dependencies
-	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --prefer-dist --no-interaction --no-suggest
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --prefer-dist --no-interaction --no-suggest
 
 lowest: clean ## Install lowest php dependencies
-	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --ansi --no-suggest --prefer-dist --prefer-lowest
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --no-suggest --prefer-dist --prefer-lowest
 
 test: ## Execute php tests and linters
-	$(dc_bin) run $(RUN_APP_ARGS) composer test
+	docker-compose run $(RUN_APP_ARGS) app composer test
 
 test-cover: ## Execute php tests with coverage
-	$(dc_bin) run --rm --user "0:0" app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer phpunit-cover"'
+	docker-compose run --rm --user "0:0" app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer phpunit-cover"'
 
 shell: ## Start shell into container with php
-	$(dc_bin) run -e "PS1=\[\033[1;32m\]\[\033[1;36m\][\u@docker] \[\033[1;34m\]\w\[\033[0;35m\] \[\033[1;36m\]# \[\033[0m\]" \
-    $(RUN_APP_ARGS) sh
+	docker-compose run $(RUN_APP_ARGS) app sh
 
 clean: ## Remove all dependencies and unimportant files
 	-rm -Rf ./composer.lock ./vendor ./coverage

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Demonstration is [available here][demo].
 Require this package with composer using the following command:
 
 ```shell
-$ composer require avto-dev/vehicle-logotypes "^2.0"
+$ composer require avto-dev/vehicle-logotypes "^2.3"
 ```
 
 > Installed `composer` is required ([how to install composer][getcomposer]).
@@ -133,7 +133,7 @@ This package is open-sourced software licensed under the [MIT License][link_lice
 
 [badge_packagist_version]:https://img.shields.io/packagist/v/avto-dev/vehicle-logotypes.svg?maxAge=180
 [badge_php_version]:https://img.shields.io/packagist/php-v/avto-dev/vehicle-logotypes.svg?longCache=true
-[badge_build_status]:https://travis-ci.org/avto-dev/vehicle-logotypes.svg?branch=master
+[badge_build_status]:https://img.shields.io/github/workflow/status/avto-dev/vehicle-logotypes/tests?maxAge=30
 [badge_coverage]:https://img.shields.io/codecov/c/github/avto-dev/vehicle-logotypes/master.svg?maxAge=60
 [badge_downloads_count]:https://img.shields.io/packagist/dt/avto-dev/vehicle-logotypes.svg?maxAge=180
 [badge_license]:https://img.shields.io/packagist/l/avto-dev/vehicle-logotypes.svg?longCache=true

--- a/composer.json
+++ b/composer.json
@@ -16,23 +16,22 @@
     ],
     "require": {
         "php": "^7.2",
-        "ext-json": "*",
-        "illuminate/support": "^5.5 || ~6.0 || ~7.0",
-        "tarampampam/wrappers-php": "^1.3"
+        "illuminate/support": "~6.0 || ~7.0 || ~8.0",
+        "tarampampam/wrappers-php": "^1.3 || ~2.0"
     },
     "require-dev": {
         "ext-mbstring": "*",
         "phpstan/phpstan": "^0.12",
-        "phpunit/phpunit": "^6.4 || ~7.5"
+        "phpunit/phpunit": "^8.0 || ^9.3"
     },
     "autoload": {
         "psr-4": {
-            "AvtoDev\\VehicleLogotypes\\": "sdk/php/src"
+            "AvtoDev\\VehicleLogotypes\\": "sdk/php/src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "AvtoDev\\VehicleLogotypes\\Tests\\": "sdk/php/tests"
+            "AvtoDev\\VehicleLogotypes\\Tests\\": "sdk/php/tests/"
         }
     },
     "scripts": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    environment:
+      PS1: '\[\033[1;32m\]\[\033[1;36m\][\u@docker] \[\033[1;34m\]\w\[\033[0;35m\] \[\033[1;36m\]# \[\033[0m\]'
     volumes:
       - /etc/passwd:/etc/passwd:ro
       - /etc/group:/etc/group:ro

--- a/sdk/php/phpunit.xml.dist
+++ b/sdk/php/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="./../../vendor/phpunit/phpunit/phpunit.xsd"
          backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"

--- a/sdk/php/tests/VehicleLogotypesTest.php
+++ b/sdk/php/tests/VehicleLogotypesTest.php
@@ -97,11 +97,11 @@ class VehicleLogotypesTest extends TestCase
     public function testStructure(): void
     {
         foreach ($this->instance as $key => $item) {
-            $this->assertInternalType('string', $key);
+            $this->assertIsString($key);
             $this->assertNotEmpty($key);
             $this->assertRegExp('~[a-z0-9\-]+~', $key);
 
-            $this->assertInternalType('string', $item['name']);
+            $this->assertIsString($item['name']);
             $this->assertNotEmpty($item['name']);
             $this->assertRegExp('~[a-zA-Z0-9\-\ ]+~', $item['name']);
 
@@ -142,16 +142,16 @@ class VehicleLogotypesTest extends TestCase
         }
 
         foreach (['uri', 'mime'] as $should_be_string) {
-            $this->assertInternalType('string', $data[$should_be_string]);
+            $this->assertIsString($data[$should_be_string]);
             $this->assertNotEmpty($data[$should_be_string]);
         }
 
         foreach (['width', 'height', 'size'] as $should_be_integer) {
-            $this->assertInternalType('integer', $data[$should_be_integer]);
+            $this->assertIsInt($data[$should_be_integer]);
             $this->assertGreaterThanOrEqual(1, $data[$should_be_integer]);
         }
 
-        $this->assertInternalType('boolean', $data['transparent']);
+        $this->assertIsBool($data['transparent']);
 
         $this->assertIsValidUri($data['uri']);
     }


### PR DESCRIPTION
## Description

### Changed

- Laravel `8.x` is supported
- Minimal Laravel version now is `6.0` (Laravel `5.5` LTS got last security update August 30th, 2020)
- Dependency `tarampampam/wrappers-php` version `~2.0` is supported

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
